### PR TITLE
nil-unless

### DIFF
--- a/src/hara/common/primitives.clj
+++ b/src/hara/common/primitives.clj
@@ -96,3 +96,24 @@
       (doseq [i   (range total)]
         (aset arr i (nth seq i)))
       arr)))
+
+(defmacro nil-unless
+  "Returns the value of the given `arg' or a list containing
+  all the arguments (if there are `more`) including `arg`,
+  when the predicate `pred` called on them does not return
+  `nil` nor `false`. Otherwise it returns `nil`.
+
+  (nil-unless odd? 3) => 3
+
+  (nil-unless odd? 2) => nil
+
+  (nil-unless = 2 2 (inc 1)) => (2 2 2)
+
+  (nil-unless = 2 2 3) => nil
+
+  (some #(nil-unless even? %) [1 2 3 4]) => 2"
+  {:added "2.1"}
+  ([pred arg]
+     `(if (~pred ~arg) ~arg nil))
+  ([pred arg & more]
+     `(if (~pred ~arg ~@more) (list ~arg ~@more) nil)))

--- a/test/hara/common/primitives_test.clj
+++ b/test/hara/common/primitives_test.clj
@@ -60,3 +60,16 @@
     (aget a 0) => "a"
 
     (count a) => 3))
+
+^{:refer hara.common.primitives/nil-unless :added "2.1"}
+(fact "Returns `nil` unless the given predicate called on other argument(s) returns true"
+
+   (nil-unless even? 2) => 2
+
+   (nil-unless odd? 2) => nil
+
+   (nil-unless = 2 2 2) => '(2 2 2)
+
+   (nil-unless = 2 2 3) => nil
+
+   (nil-unless not= 2 2 3) => '(2 2 3))


### PR DESCRIPTION
This macro adds readability in some cases, like in anonymous functions passed as predicates.

