### PR TITLE
Allow all list-like structures to be special forms

### DIFF
--- a/src/hara/event/condition/util.clj
+++ b/src/hara/event/condition/util.clj
@@ -8,7 +8,7 @@
 
 (defn is-special-form
   ([k form]
-     (and (list? form)
+     (and (instance? clojure.lang.ISeq form)
           (symbol? (first form))
           (contains? (sp-forms k) (first form))))
   ([k form syms]


### PR DESCRIPTION
This includes LazySeq, Cons and maybe some others.

Easier to explain with code:
```clojure
(require '[hara.event :as ev])

(defn issue-fn []
  (ev/raise ::some-issue
            (option :use-value [v] v)))

(ev/manage (issue-fn)
           (on ::some-issue [] (ev/choose :use-value 42)))
;=> 42

(defmacro always-choose [form value]
  `(ev/manage ~form
              (~'on ::some-issue [] (ev/choose :use-value ~value))))

(always-choose (issue-fn) 42)
;; Unable to resolve symbol: on in this context

;;; But...

(defmacro always-choose2 [form value]
  `(ev/manage ~form
              ~(clojure.lang.PersistentList/create ;; WOW!
                `(~'on ::some-issue [] (ev/choose :use-value ~value)))))

(always-choose2 (issue-fn) 42)
;=> 42

(= (macroexpand-1 '(always-choose2 (issue-fn) 42))
   (macroexpand-1 '(always-choose2 (issue-fn) 42)))
;=> true

(= (macroexpand-1 (macroexpand-1 '(always-choose2 (issue-fn) 42)))
   (macroexpand-1 (macroexpand-1 '(always-choose2 (issue-fn) 42))))
;=> false
```