### PR TITLE
Handle java.versions with alpha chars

### DIFF
--- a/src/hara/io/environment.clj
+++ b/src/hara/io/environment.clj
@@ -31,7 +31,8 @@
   {:added "2.2"}
   []
   (let [[major minor incremental qualifier]
-        (->> (path/split (System/getProperty "java.version") #"[\._]")
+        (->> (path/split (System/getProperty "java.version") #"[\._-]")
+             (take 4)
              (map #(Long/parseLong %)))]
     {:major major
      :minor minor


### PR DESCRIPTION
Heroku's java.version strings look like "1.8.0_74-cedar14", so java-version throws a NumberFormatException executing (Long/parseLong "74-cedar14")

This patch will fix the heroku case, but two better options may be to drop the qualifier altogether (if it's not needed), or leave it as a string?