### PR TITLE
Fix data.diff when diffing maps with falsey values

### DIFF
--- a/src/hara/data/diff.clj
+++ b/src/hara/data/diff.clj
@@ -18,16 +18,16 @@
    (diff-changes m1 m2 []))
   ([m1 m2 arr]
    (reduce-kv (fn [out k1 v1]
-                (if-let [v2 (and (contains? m2 k1)
-                                 (get m2 k1))]
-                  (cond (and (hash-map? v1) (hash-map? v2))
-                        (merge out (diff-changes v1 v2 (conj arr k1)))
+                (if (contains? m2 k1)
+                  (let [v2 (get m2 k1)]
+                    (cond (and (hash-map? v1) (hash-map? v2))
+                          (merge out (diff-changes v1 v2 (conj arr k1)))
 
-                        (= v1 v2)
-                        out
+                          (= v1 v2)
+                          out
 
-                        :else
-                        (assoc out (conj arr k1) v1))
+                          :else
+                          (assoc out (conj arr k1) v1)))
                   out))
               {}
               m1)))

--- a/test/hara/data/diff_test.clj
+++ b/test/hara/data/diff_test.clj
@@ -16,7 +16,19 @@
   => {}
 
   (diff-changes {:a 1 :b 2} {:a 1 :b 2 :c 3})
-  => {})
+  => {}
+
+  (diff-changes {:a 1} {:a nil})
+  => {[:a] 1}
+
+  (diff-changes {:a nil} {:a 1})
+  => {[:a] nil}
+
+  (diff-changes {:a true} {:a false})
+  => {[:a] true}
+
+  (diff-changes {:a false} {:a true})
+  => {[:a] false})
 
 ^{:refer hara.data.diff/diff-new :added "2.1"}
 (fact "Finds new elements in nested maps, does not consider changes"


### PR DESCRIPTION
The if-let in diff-changes was being bypassed if m2 contained nil or false. This patch fixes the behaviour, and adds failing tests that pass when the fix is applied.