### PR TITLE
Fix invalid ns form

### DIFF
--- a/src/hara/reflect/pretty/classes.clj
+++ b/src/hara/reflect/pretty/classes.clj
@@ -1,7 +1,7 @@
 (ns hara.reflect.pretty.classes
-  (require [hara.reflect.common :refer :all]
-           [hara.reflect.pretty.primitives :refer :all]
-           [hara.common.string :as string]))
+  (:require [hara.reflect.common :refer :all]
+            [hara.reflect.pretty.primitives :refer :all]
+            [hara.common.string :as string]))
 
 (def class-reps #{:raw :symbol :string :class :container})
 


### PR DESCRIPTION
Latest clojure 1.9 alpha11 throws on bad ns macro form.