### PR TITLE
Exclude new clojure1.9 type predicates

### DIFF
--- a/src/hara/common.clj
+++ b/src/hara/common.clj
@@ -3,7 +3,8 @@
             [hara.common.checks]
             [hara.common.hash]
             [hara.common.error]
-            [hara.common.primitives]))
+            [hara.common.primitives])
+  (:refer-clojure :exclude [boolean? double? bigdec? uuid? uri? bytes?]))
 
 (ns/import
   hara.common.checks      :all

--- a/src/hara/common/checks.clj
+++ b/src/hara/common/checks.clj
@@ -1,4 +1,5 @@
-(ns hara.common.checks)
+(ns hara.common.checks
+  (:refer-clojure :exclude [boolean? double? bigdec? uuid? uri? bytes?]))
 
 ;; ## Type Predicates
 ;;

--- a/src/hara/common/primitives.clj
+++ b/src/hara/common/primitives.clj
@@ -1,5 +1,5 @@
 (ns hara.common.primitives
-  (:require [hara.common.checks :refer [bytes?]]
+  (:require [hara.common.checks :as checks]
             [hara.common.error :refer [error]]))
 
 (defn T
@@ -51,7 +51,7 @@
   ([id]
      (cond (string? id)
            (java.util.UUID/fromString id)
-           (bytes? id)
+           (checks/bytes? id)
            (java.util.UUID/nameUUIDFromBytes id)
            :else (error id " can only be a string or byte array")))
   ([^Long msb ^Long lsb]


### PR DESCRIPTION
Excludes new Clojure1.9 predicates from `hara.common.checks`, `hara.common` and `hara.common.primitives`. Backwards compatible with old Clojure versions. Fixes #22.

* `long?` was later [removed from 1.9](https://github.com/clojure/clojure/commit/20f67081b7654e44e960defb1e4e491c3a0c2c8b)